### PR TITLE
Initialize syscall_count

### DIFF
--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -146,6 +146,8 @@ found:
   p->context.ra = (uint64)forkret;
   p->context.sp = p->kstack + PGSIZE;
 
+  p->syscall_count = 0; // Initialize syscall count
+
   return p;
 }
 
@@ -168,6 +170,7 @@ freeproc(struct proc *p)
   p->chan = 0;
   p->killed = 0;
   p->xstate = 0;
+  p->syscall_count = 0; // Reset syscall count on free
   p->state = UNUSED;
 }
 


### PR DESCRIPTION
Initialize syscall_count to 0 when a process structure is allocated.